### PR TITLE
Localized URLs and set_locale feature

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,18 @@
 class ApplicationController < ActionController::Base
+  before_action :set_locale
+
+  def set_locale
+    I18n.locale = find_locale || I18n.default_locale
+  end
+
+  def default_url_options(options={})
+    { locale: I18n.locale }
+  end
+
+  private
+
+  def find_locale
+    parsed_locale = params[:locale].try(:to_sym)
+    I18n.available_locales.include?(parsed_locale) ? parsed_locale : nil
+  end
 end

--- a/app/controllers/locale_controller.rb
+++ b/app/controllers/locale_controller.rb
@@ -1,0 +1,6 @@
+class LocaleController < ApplicationController
+  def update
+    set_locale
+    redirect_to request.referrer.gsub(%r{\/#{params[:locale]}\/}, "/#{params[:new_locale]}/")
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,11 +37,10 @@
               <p class="text-muted">Add some information about the page here, the author, or any other background context. Make it a few sentences long so folks can pick up some informative tidbits. Then, link them off to some social networking sites or contact information.</p>
             </div>
             <div class="col-sm-4 offset-md-1 py-4">
-              <h4>Contact</h4>
+              <h4>Language</h4>
               <ul class="list-unstyled">
-                <li><a href="#">Follow on Twitter</a></li>
-                <li><a href="#">Like on Facebook</a></li>
-                <li><a href="#">Email me</a></li>
+                <li><%= link_to "English", set_locale_path(new_locale: 'en') %></li>
+                <li><%= link_to "日本語", set_locale_path(new_locale: 'ja') %></li>
               </ul>
             </div>
           </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,11 @@
 Rails.application.routes.draw do
-  devise_for :users
-  root to: 'urls#index'
-  resources :urls, param: :slug
+  scope "(:locale)", locale: /#{I18n.available_locales.join("|")}/ do
+    get '/set_locale/:new_locale', to: 'locale#update', as: :set_locale
 
-  get '/:slug', to: 'urls#show'
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+    devise_for :users
+    root to: 'urls#index'
+    resources :urls, param: :slug
+
+    get '/:slug', to: 'urls#show'
+  end
 end


### PR DESCRIPTION
Ref issue #17 

- Added `scope "(:locale)"` to all routes, so we can prepend the locale (`en` or `ja`) in the beginning of all URLs to set the language. E.g.:
  - `http://wwcode.jp/en/users/sign_in` => English login page
  - `http://wwcode.jp/ja/users/sign_in` => Japanese login page
- Added language switcher to the collapsed header
  - Plus `LocaleController` to take care of switching the language and redirecting back to the same url (with new locale scope)
- Added `set_location` before action callback to set the language before every action in every controller
- Added `default_url_options` to set the `locale` param every time, so we don't need to pass it every time we call a path helper. E.g.:
  - `users_path` is fine, no need for `users_path(locale: 'en')`

Demo:

![set_locale_demo](https://user-images.githubusercontent.com/1096046/59567785-3a197680-90ad-11e9-8699-29876538eb05.gif)
